### PR TITLE
Add support for reading events streamed and in compact format

### DIFF
--- a/seq-import.sln
+++ b/seq-import.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "asset", "asset", "{604C58AE
 		asset\seq-import.ico = asset\seq-import.ico
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "seq-import.Tests", "test\seq-import.Tests\seq-import.Tests.csproj", "{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,11 +35,16 @@ Global
 		{D3E7EC4A-5D05-475E-ACD1-05E979BC4320}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3E7EC4A-5D05-475E-ACD1-05E979BC4320}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3E7EC4A-5D05-475E-ACD1-05E979BC4320}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D3E7EC4A-5D05-475E-ACD1-05E979BC4320} = {D0649092-5A4D-4071-A51C-0410F67E9206}
+		{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1} = {9359C82A-D7EF-4977-9FE0-2A0E0094C1AE}
 	EndGlobalSection
 EndGlobal

--- a/src/seq-import/EventConverter.cs
+++ b/src/seq-import/EventConverter.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace seq_import
+{
+    public class EventConverter
+    {
+        /*
+{
+	"Timestamp": "2016-06-07T13:44:57.8532799+10:00",
+	"Level": "Information",
+	"MessageTemplate": "Hello, {@User}, {N:x8} at {Now}",
+	"Exception": "System.Exception: Exception of type \"System.Exception\" was thrown",
+	"Properties": {
+		"User": {
+			"Name": "nblumhardt",
+			"Tags": [1, 2, 3]
+		},
+		"N": 123,
+		"Now": "2016-06-07T13:44:57.8532799+10:00"
+	},
+	"Renderings": {
+		"N": [{
+			"Format": "x8",
+			"Rendering": "0000007b"
+		}]
+	}
+}
+
+{
+	"@t": "2016-06-07T03:44:57.8532799Z",
+	"@mt": "Hello, {@User}, {N:x8} at {Now}",
+	"@r": ["0000007b"],
+    "@x": "System.Exception: Exception of type \"System.Exception\" was thrown",
+	"User": {
+		"Name": "nblumhardt",
+		"Tags": [1,
+		2,
+		3]
+	},
+	"N": 123,
+	"Now": "2016-06-07T13:44:57.8532799+10:00"
+}
+        */
+
+        public static JObject ConvertToCompactJson(JObject entry)
+        {
+            var compact = new JObject();
+
+            var offset = DateTimeOffset.ParseExact(entry["Timestamp"].ToString(), "o", CultureInfo.InvariantCulture);
+            compact["@t"] = offset.UtcDateTime.ToString("O");
+
+            if (entry["Level"].ToString() != "Information")
+            {
+                compact["@l"] = entry["Level"];
+            }
+
+            if (entry["Message"] != null)
+            {
+                compact["@m"] = entry["Message"];
+            }
+
+            if (entry["MessageTemplate"] != null)
+            {
+                compact["@mt"] = entry["MessageTemplate"];
+            }
+
+            if (entry["Exception"] != null)
+            {
+                compact["@x"] = entry["Exception"];
+            }
+
+            if (entry["Properties"] != null)
+            {
+                foreach (var property in entry["Properties"])
+                {
+                    compact.Add(property);
+                }
+            }
+
+            return compact;
+        }
+
+        public static JObject ConvertToDefaultJson(JObject compact)
+        {
+            var entry = new JObject();
+
+            var timestamp = DateTime.ParseExact(compact["@t"].ToString(), "O", CultureInfo.InvariantCulture);
+            entry["Timestamp"] = new DateTimeOffset(timestamp).ToUniversalTime().ToString("o");
+
+            entry["Level"] = compact["@l"]?.ToString() ?? "Information";
+
+            if (compact["@m"] != null)
+            {
+                entry["Message"] = compact["@m"];
+            }
+
+            if (compact["@mt"] != null)
+            {
+                entry["MessageTemplate"] = compact["@mt"];
+            }
+
+            if (compact["@x"] != null)
+            {
+                entry["Exception"] = compact["@x"];
+            }
+
+            var properties = new JObject();
+            entry["Properties"] = properties;
+
+            foreach (var property in compact.OfType<JProperty>())
+            {
+                switch (property.Name)
+                {
+                    case "@t":
+                    case "@m":
+                    case "@mt":
+                    case "@l":
+                    case "@x":
+                    case "@i":
+                    case "@r":
+                        continue;
+                    default:
+                        properties.Add(property);
+                        break;
+                }
+            }
+
+            return entry;
+        }
+
+        public static JObject PassThrough(JObject input)
+        {
+            return input;
+        }
+    }
+}

--- a/src/seq-import/EventConverter.cs
+++ b/src/seq-import/EventConverter.cs
@@ -74,9 +74,23 @@ namespace seq_import
 
             if (entry["Properties"] != null)
             {
-                foreach (var property in entry["Properties"])
+                foreach (var property in entry["Properties"].OfType<JProperty>())
                 {
-                    compact.Add(property);
+                    switch (property.Name)
+                    {
+                        case "@t":
+                        case "@m":
+                        case "@mt":
+                        case "@l":
+                        case "@x":
+                        case "@i":
+                        case "@r":
+                            compact["@" + property.Name] = property.Value;
+                            break;
+                        default:
+                            compact.Add(property);
+                            break;
+                    }
                 }
             }
 

--- a/src/seq-import/LogBufferEntry.cs
+++ b/src/seq-import/LogBufferEntry.cs
@@ -1,6 +1,6 @@
 namespace seq_import
 {
-    class LogBufferEntry
+    struct LogBufferEntry
     {
         public ulong Key;
         public byte[] Value;

--- a/src/seq-import/PropertyEnricher.cs
+++ b/src/seq-import/PropertyEnricher.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace seq_import
+{
+    public class PropertyEnricher
+    {
+        public static void AddPropertiesToCompactJson(JObject entry, Dictionary<string, object> additionalProperties)
+        {
+            if (!(additionalProperties?.Count > 0))
+                return;
+
+            foreach (var kvp in additionalProperties)
+            {
+                switch (kvp.Key)
+                {
+                    case "@t":
+                    case "@m":
+                    case "@mt":
+                    case "@l":
+                    case "@x":
+                    case "@i":
+                    case "@r":
+                        entry["@" + kvp.Key] = JToken.FromObject(kvp.Value);
+                        break;
+                    default:
+                        entry[kvp.Key] = JToken.FromObject(kvp.Value);
+                        break;
+                }
+            }
+        }
+
+        public static void AddPropertiesToDefaultJson(JObject entry, Dictionary<string, object> additionalProperties)
+        {
+            if (!(additionalProperties?.Count > 0))
+                return;
+
+            var properties = entry["Properties"] as JObject;
+            if (properties == null)
+            {
+                properties = new JObject();
+                entry["Properties"] = properties;
+            }
+
+            foreach (var kvp in additionalProperties)
+            {
+                properties[kvp.Key] = JToken.FromObject(kvp.Value);
+            }
+        }
+    }
+}

--- a/src/seq-import/SeqImportConfig.cs
+++ b/src/seq-import/SeqImportConfig.cs
@@ -6,5 +6,6 @@
         public ulong EventBodyLimitBytes { get; set; }
         public ulong RawPayloadLimitBytes { get; set; }
         public string ApiKey { get; set; }
+        public bool CompactJson { get; set; }
     }
 }

--- a/src/seq-import/StreamingEventReader.cs
+++ b/src/seq-import/StreamingEventReader.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog;
+
+namespace seq_import
+{
+    class StreamingEventReader : IEnumerable<LogBufferEntry>
+    {
+        // Doing our best here to create a totally "neutral" serializer; may need some more work
+        // to avoid special-casing .NET types in any circumstances.
+        readonly JsonSerializer _serializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            DateParseHandling = DateParseHandling.None,
+            //Binder = new NonBindingSerializationBinder(),
+            TypeNameHandling = TypeNameHandling.None
+        });
+
+        ulong _nextId = 1;
+
+        private string file;
+        private Dictionary<string, object> tags;
+        private Func<JObject, JObject> eventProcessor;
+        private Action<JObject, Dictionary<string, object>> propertyEnricher;
+
+        public StreamingEventReader(string file, Dictionary<string, object> tags, Func<JObject, JObject> eventProcessor, Action<JObject, Dictionary<string, object>> propertyEnricher)
+        {
+            if (file == null) throw new ArgumentNullException(nameof(file));
+            if (tags == null) throw new ArgumentNullException(nameof(tags));
+            if (eventProcessor == null) throw new ArgumentNullException(nameof(eventProcessor));
+            if (propertyEnricher == null) throw new ArgumentNullException(nameof(propertyEnricher));
+
+            this.file = file;
+            this.tags = tags;
+            this.eventProcessor = eventProcessor;
+            this.propertyEnricher = propertyEnricher;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<LogBufferEntry> GetEnumerator()
+        {
+            var encoding = new UTF8Encoding(false);
+
+            using (var r = File.OpenText(file))
+            using (var bytes = new MemoryStream())
+            using (var writer = new JsonTextWriter(new StreamWriter(bytes, encoding, 1024, leaveOpen: true)))
+            {
+                int line = 0;
+                for (var l = r.ReadLine(); l != null; l = r.ReadLine())
+                {
+                    line++;
+
+                    if (l.Length == 0) continue;
+
+                    bytes.SetLength(0);
+                    try
+                    {
+                        var json = _serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(l)));
+                        json = eventProcessor(json);
+                        propertyEnricher(json, tags);
+
+                        _serializer.Serialize(writer, json);
+                        writer.Flush();
+                    }
+                    catch (JsonException ex)
+                    {
+                        Log.Error(ex, "Line {Line} is not valid JSON; skipping", line);
+                        continue;
+                    }
+
+                    yield return new LogBufferEntry { Key = _nextId++, Value = bytes.ToArray() };
+                }
+            }
+        }
+    }
+}

--- a/src/seq-import/packages.config
+++ b/src/seq-import/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="docopt.net" version="0.6.1.6" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
-  <package id="Serilog" version="1.5.14" targetFramework="net451" />
-  <package id="Serilog.Sinks.Literate" version="1.2.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Serilog" version="2.3.0" targetFramework="net451" />
+  <package id="Serilog.Sinks.Literate" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/src/seq-import/seq-import.csproj
+++ b/src/seq-import/seq-import.csproj
@@ -64,13 +64,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventConverter.cs" />
     <Compile Include="HttpImporter.cs" />
     <Compile Include="LogBuffer.cs" />
     <Compile Include="LogBufferEntry.cs" />
     <Compile Include="NonBindingSerializationBinder.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyEnricher.cs" />
     <Compile Include="SeqImportConfig.cs" />
+    <Compile Include="StreamingEventReader.cs" />
     <Compile Include="UnclosableStreamWrapper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/seq-import/seq-import.csproj
+++ b/src/seq-import/seq-import.csproj
@@ -42,20 +42,16 @@
       <HintPath>..\..\packages\docopt.net.0.6.1.6\lib\net40\DocoptNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.Sinks.Literate, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.Literate.1.2.0\lib\net45\Serilog.Sinks.Literate.dll</HintPath>
+    <Reference Include="Serilog.Sinks.Literate, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.Literate.2.0.0\lib\net45\Serilog.Sinks.Literate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/seq-import.Tests/JsonTestData.cs
+++ b/test/seq-import.Tests/JsonTestData.cs
@@ -1,0 +1,63 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace seq_import.Tests
+{
+    class JsonTestData
+    {
+        private static JObject ToJObject(string json)
+        {
+            using (var reader = new JsonTextReader(new StringReader(json)))
+            {
+                reader.DateParseHandling = DateParseHandling.None;
+                return JObject.Load(reader);
+            }
+        }
+
+        public static JObject GetDefaultJson()
+        {
+            string json =
+   @"{
+	""Timestamp"": ""2016-06-07T13:44:57.8532799+10:00"",
+	""Level"": ""Information"",
+	""MessageTemplate"": ""Hello, {@User}, {N:x8} at {Now}"",
+	""Exception"": ""System.Exception: Exception of type \""System.Exception\"" was thrown"",
+	""Properties"": {
+		""User"": {
+			""Name"": ""nblumhardt"",
+			""Tags"": [1, 2, 3]
+		},
+		""N"": 123,
+		""Now"": ""2016-06-07T13:44:57.8532799+10:00""
+	},
+	""Renderings"": {
+		""N"": [{
+			""Format"": ""x8"",
+			""Rendering"": ""0000007b""
+		}]
+	}
+}";
+
+            return ToJObject(json);
+        }
+
+        public static JObject GetCompactJson()
+        {
+            var json = @"{
+	""@t"": ""2016-06-07T03:44:57.8532799Z"",
+	""@mt"": ""Hello, {@User}, {N:x8} at {Now}"",
+	""@r"": [""0000007b""],
+	""@x"": ""System.Exception: Exception of type \""System.Exception\"" was thrown"",
+	""User"": {
+		""Name"": ""nblumhardt"",
+		""Tags"": [1, 2, 3]
+	},
+	""N"": 123,
+	""Now"": ""2016-06-07T13:44:57.8532799+10:00""
+}";
+
+            return ToJObject(json);
+        }
+    }
+}

--- a/test/seq-import.Tests/LogFileConversionTests.cs
+++ b/test/seq-import.Tests/LogFileConversionTests.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace seq_import.Tests
+{
+    [TestClass]
+    public class LogFileConversionTests
+    {
+        private static JObject ToJObject(string json)
+        {
+            using (var reader = new JsonTextReader(new StringReader(json)))
+            {
+                reader.DateParseHandling = DateParseHandling.None;
+                return JObject.Load(reader);
+            }
+        }
+
+        [TestMethod]
+        public void TestConversionToCompact()
+        {
+            var compactJson = EventConverter.ConvertToCompactJson(JsonTestData.GetDefaultJson());
+
+            Assert.AreEqual(compactJson["@t"].ToString(), "2016-06-07T03:44:57.8532799Z");
+            Assert.AreEqual(compactJson["@mt"].ToString(), "Hello, {@User}, {N:x8} at {Now}");
+            Assert.AreEqual(compactJson["@x"].ToString(), "System.Exception: Exception of type \"System.Exception\" was thrown");
+            Assert.AreEqual(compactJson["User"]["Name"].ToString(), "nblumhardt");
+            Assert.IsTrue(compactJson["User"]["Tags"].Values<int>().SequenceEqual(new int[] { 1, 2, 3 }));
+            Assert.AreEqual(compactJson["N"].ToString(), "123");
+            Assert.AreEqual(compactJson["Now"].ToString(), "2016-06-07T13:44:57.8532799+10:00");
+        }
+
+        [TestMethod]
+        public void TestConversionToDefaultJson()
+        {
+            var defaultJson = EventConverter.ConvertToDefaultJson(JsonTestData.GetCompactJson());
+
+            Assert.AreEqual(defaultJson["Timestamp"].ToString(), "2016-06-07T03:44:57.8532799+00:00");
+            Assert.AreEqual(defaultJson["Level"].ToString(), "Information");
+            Assert.AreEqual(defaultJson["MessageTemplate"].ToString(), "Hello, {@User}, {N:x8} at {Now}");
+            Assert.AreEqual(defaultJson["Exception"].ToString(), "System.Exception: Exception of type \"System.Exception\" was thrown");
+            Assert.AreEqual(defaultJson["Properties"]["User"]["Name"].ToString(), "nblumhardt");
+            Assert.IsTrue(defaultJson["Properties"]["User"]["Tags"].Values<int>().SequenceEqual(new int[] { 1, 2, 3 }));
+            Assert.AreEqual(defaultJson["Properties"]["N"].ToString(), "123");
+            Assert.AreEqual(defaultJson["Properties"]["Now"].ToString(), "2016-06-07T13:44:57.8532799+10:00");
+        }
+    }
+}

--- a/test/seq-import.Tests/Properties/AssemblyInfo.cs
+++ b/test/seq-import.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("seq-import.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("seq-import.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("88eb4856-7f63-4e02-9435-4fe8ee6bcad1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/seq-import.Tests/PropertyEnrichmentTests.cs
+++ b/test/seq-import.Tests/PropertyEnrichmentTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace seq_import.Tests
+{
+    [TestClass]
+    public class PropertyEnrichmentTests
+    {
+        [TestMethod]
+        public void TestEnrichCompactJson()
+        {
+            var additionalProperties = new Dictionary<string, object>
+            {
+                ["@x"] = "test",
+                ["Number"] = 1
+            };
+
+            JObject logEvent = JsonTestData.GetCompactJson();
+            PropertyEnricher.AddPropertiesToCompactJson(logEvent, additionalProperties);
+
+            Assert.AreEqual(logEvent["@x"].ToString(), "System.Exception: Exception of type \"System.Exception\" was thrown");
+            Assert.AreEqual(logEvent["@@x"].ToString(), "test");
+            Assert.AreEqual(logEvent["Number"].ToString(), "1");
+        }
+
+        [TestMethod]
+        public void TestEnrichDefaultJson()
+        {
+            var additionalProperties = new Dictionary<string, object>
+            {
+                ["@x"] = "test",
+                ["Number"] = 1
+            };
+
+            JObject logEvent = JsonTestData.GetDefaultJson();
+            PropertyEnricher.AddPropertiesToDefaultJson(logEvent, additionalProperties);
+
+            Assert.AreEqual(logEvent["Properties"]["@x"].ToString(), "test");
+            Assert.AreEqual(logEvent["Properties"]["Number"].ToString(), "1");
+        }
+    }
+}

--- a/test/seq-import.Tests/app.config
+++ b/test/seq-import.Tests/app.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+  </startup>
+</configuration>

--- a/test/seq-import.Tests/packages.config
+++ b/test/seq-import.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.1.6-preview" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.0.7-preview" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+</packages>

--- a/test/seq-import.Tests/seq-import.Tests.csproj
+++ b/test/seq-import.Tests/seq-import.Tests.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{88EB4856-7F63-4E02-9435-4FE8EE6BCAD1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>seq_import.Tests</RootNamespace>
+    <AssemblyName>seq-import.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="JsonTestData.cs" />
+    <Compile Include="LogFileConversionTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyEnrichmentTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\seq-import\seq-import.csproj">
+      <Project>{d3e7ec4a-5d05-475e-acd1-05e979bc4320}</Project>
+      <Name>seq-import</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props'))" />
+  </Target>
+</Project>


### PR DESCRIPTION
Hi Nicholas, made some improvements, hope you don't mind 😄

- Allows to specify wether to read input as default or compact json and wether to post it as default or compact json to seq (converting on the fly; doesn't deal with `Renderings` though but they are preserved when passing through, e.g. `--compact-input` and `--compact-output` or default input and default output). 
- Events are now read streamed into the buffer allowing to deal with arbitrary large json files. They are temporarily buffered though for the pseudo binary search when the bulk upload failed. I also have another version of the `StreamingEventReader` where the `JsonTextReader` is used in `SupportMultipleContent` mode which yields about 5% better performance but doesn't play nicely with malformed JSON. Anyhow this should fix #4 
- Reduces GC pressure by reusing buffers. Lots of code were allocating objects like MemoryStreams and throwing them away on every iteration. Keeping them around and using `SetLength(0)` allows reusing them so the backing array doesn't need to be re-allocated.
- Added some tests for event conversion and property enrichment

In my tests i could import a 160MB compact json file with around 5% cpu consumption and 14~16MB RAM usage, mainly bottlenecked by Seq.